### PR TITLE
Fix: hreokuにpushできるようにgemfileをロック #18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
+      racc (~> 1.4)
     pg (1.2.3)
     puma (4.3.10)
       nio4r (~> 2.0)
@@ -172,6 +174,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)


### PR DESCRIPTION
## 概要
herokuにプッシュできるようにbundlerのバージョンをロックしました｡