### PR TITLE
Add: タイムゾーン変更 #35

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,8 @@ module Sakanarish
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
## 概要
RailsアプリケーションとDBのタイムゾーンを変更
config/application.rbに下記を追記
`config.time_zone = 'Tokyo'`
`config.active_record.default_timezone = :local`
