### PR TITLE
Fix: 小数点付きの数値を扱えるようにFishNutrientのnutritional_valueのデータ型を変更 #46

### DIFF
--- a/app/models/fish_nutrient.rb
+++ b/app/models/fish_nutrient.rb
@@ -3,7 +3,7 @@
 # Table name: fish_nutrients
 #
 #  id                   :bigint           not null, primary key
-#  nutritional_value    :integer          not null
+#  nutritional_value    :float(24)        not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  fish_id              :bigint           not null

--- a/db/migrate/20211021083624_change_data_nutritional_value_to_fish_nutrient.rb
+++ b/db/migrate/20211021083624_change_data_nutritional_value_to_fish_nutrient.rb
@@ -1,0 +1,5 @@
+class ChangeDataNutritionalValueToFishNutrient < ActiveRecord::Migration[6.0]
+  def change
+    change_column :fish_nutrients, :nutritional_value, :float, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_20_053834) do
+ActiveRecord::Schema.define(version: 2021_10_21_083624) do
 
   create_table "fish", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2021_10_20_053834) do
   end
 
   create_table "fish_nutrients", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.integer "nutritional_value", null: false
+    t.float "nutritional_value", null: false
     t.bigint "fish_id", null: false
     t.bigint "nutrient_category_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/fish_nutrients.rb
+++ b/spec/factories/fish_nutrients.rb
@@ -3,7 +3,7 @@
 # Table name: fish_nutrients
 #
 #  id                   :bigint           not null, primary key
-#  nutritional_value    :integer          not null
+#  nutritional_value    :float(24)        not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  fish_id              :bigint           not null

--- a/spec/models/fish_nutrient_spec.rb
+++ b/spec/models/fish_nutrient_spec.rb
@@ -3,7 +3,7 @@
 # Table name: fish_nutrients
 #
 #  id                   :bigint           not null, primary key
-#  nutritional_value    :integer          not null
+#  nutritional_value    :float(24)        not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  fish_id              :bigint           not null


### PR DESCRIPTION
## 概要
- [x] FishNutrientのnutritional_valueのデータ型をintegerからfloatに変更
- rails g migration ChangeDataNutritionalValueToFishNutrient
## コメント
- rails db:migrate:resetでデータを一度削除
- rails db:seed_fuで再投入
- 小数点付きの数値でカラムに保存されていることを確認済み
